### PR TITLE
BAH-2156 | Fix. Datasource loading error in Grafana

### DIFF
--- a/values/logging.yaml
+++ b/values/logging.yaml
@@ -1,3 +1,7 @@
 loki:
   nodeSelector:
     eks.amazonaws.com/nodegroup: nonprod
+grafana:
+  sidecar:
+    datasources:
+      enabled: false

--- a/values/monitoring.yaml
+++ b/values/monitoring.yaml
@@ -25,9 +25,7 @@ grafana:
       url: http://loki:3100
       editable: true
       isDefault: false
-  sidecar:
-    datasources:
-      enabled: false
+
   nodeSelector:
     eks.amazonaws.com/nodegroup: nonprod
 

--- a/values/monitoring.yaml
+++ b/values/monitoring.yaml
@@ -24,6 +24,7 @@ grafana:
       access: proxy
       url: http://loki:3100
       editable: true
+      isDefault: false
   nodeSelector:
     eks.amazonaws.com/nodegroup: nonprod
 

--- a/values/monitoring.yaml
+++ b/values/monitoring.yaml
@@ -25,6 +25,9 @@ grafana:
       url: http://loki:3100
       editable: true
       isDefault: false
+  sidecar:
+    datasources:
+      enabled: false
   nodeSelector:
     eks.amazonaws.com/nodegroup: nonprod
 


### PR DESCRIPTION
This PR fixes Grafana initialisation issues due to default datasource configuration issues caused by two different stacks. So disabling datasource loading by loki-stack.