### PR TITLE
[Rahul] | BAH-3005 | Add. Timezone Global Value For Helm Charts

### DIFF
--- a/values/local.yaml
+++ b/values/local.yaml
@@ -1,3 +1,6 @@
+global:
+  TZ: "UTC"
+
 metadata:
   labels:
     environment: local


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

In this PR, we have added the TZ environment variable to the helm charts to configure the timezone for the Bahmni/[helm-umbrella-chart](https://github.com/Bahmni/helm-umbrella-chart).