### PR TITLE
BAH-3525 | Add. Configuration To Handle Zero date value prohibited Error

### DIFF
--- a/values/local.yaml
+++ b/values/local.yaml
@@ -20,6 +20,7 @@ openmrs:
     OMRS_DB_NAME: openmrs
     DEBUG: true
     OMRS_CREATE_TABLES: true
+    OMRS_DB_EXTRA_ARGS: "&zeroDateTimeBehavior=convertToNull"
 bahmni-web:
   enabled: true
 bahmni-lab:


### PR DESCRIPTION
JIRA -> [BAH-3525](https://bahmni.atlassian.net/browse/BAH-3525)

This PR addresses the "Zero date value prohibited" error configuring OMRS_DB_EXTRA_ARGS to include `&zeroDateTimeBehavior=convertToNull.

During openmrs runtime, OMRS_DB_EXTRA_ARGS sets zeroDateTimeBehavior=convertToNull in JdbcUrl. Upon boot up, openmrs utilizes its own startup script to define the jdbc url. OMRS_DB_EXTRA_ARGS appends any provided parameters to the end of the url.

By default, the connector throws an exception when encountering zero date values, as it aligns with JDBC and SQL standards. This behavior can be adjusted using the zeroDateTimeBehavior configuration property.