### PR TITLE
BAH-3635 | Add. Config For Lucene Match Type

### DIFF
--- a/values/local.yaml
+++ b/values/local.yaml
@@ -21,6 +21,7 @@ openmrs:
     DEBUG: true
     OMRS_CREATE_TABLES: true
     OMRS_DB_EXTRA_ARGS: "&zeroDateTimeBehavior=convertToNull"
+    LUCENE_MATCH_TYPE: "START"
 bahmni-web:
   enabled: true
 bahmni-lab:


### PR DESCRIPTION
JIRA -> [BAH-3635](https://bahmni.atlassian.net/browse/BAH-3635)

In this pull request, the Lucene search functionality has undergone configuration enhancements. Now, the search results vary based on the `LUCENE_MATCH_TYPE` environment variable, providing distinct outcomes for different match types:

**`EXACT`** : Only exact matches will be considered.
**`START`** : Matches that commence with the search term will be considered.
**`ANYWHERE`** : All search results containing the search term anywhere in the text will be considered.


| LUCENE_MATCH_TYPE | Search Term | Daniel  | Nielsen  |
| -----------------------  | ------------- | ------  |-------- |
| EXACT             | Daniel       | True   | False  |
|                          | Nielsen     | False  | True   | 
| START              | Niel           | False  | True   | 
|                          | niel            | False  | True   | 
| ANYWHERE     | Niel           | True   | True   |
|                           | niel           | True   | True   |